### PR TITLE
fix #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ import zero_functional
 import strutils
 # filter all lines containing the word hint in the iterator
 lines("nim.cfg") --> filter("hint" in it.string) --> createIter(errorLines)
-for a in errorLines(): echo a
+errorLines() --> foreach(echo it)
 ```
 
 ## Extending zero-functional

--- a/README.md
+++ b/README.md
@@ -450,10 +450,11 @@ Similar to `to` this is also a virtual function which is internally replaced and
 The generated iterator is inline and can not be returned from a proc or given to another proc (see [Nim: Iterators](https://nim-lang.org/docs/manual.html#iterators-and-the-for-statement-first-class-iterators)).
 
 ```nim
-# filter all lines containing the word error in the iterator
-myFileIterator --> filter("error" in it) --> createIter(errorLines)
-if debug:
-  errorLines() --> echo(it) # () must be used when working with iterators
+import zero_functional
+import strutils
+# filter all lines containing the word hint in the iterator
+lines("nim.cfg") --> filter("hint" in it.string) --> createIter(errorLines)
+for a in errorLines(): echo a
 ```
 
 ## Extending zero-functional


### PR DESCRIPTION
* fixes #34 (see https://github.com/zero-functional/zero-functional/issues/34#issuecomment-408266131)

I removed `errorLines() --> echo(it)` because of compile error:
`Error: echo is unknown, you could provide your own implementation! See `zfCreateExtension`!`
and replaced with something that compiles

more generally, how about using `runnableExamples` as in Nim code to generate documented examples that are guaranteed to stay in sync and compile and run?

