### PR TITLE
Update .gitignore: `**` should only appear as a path component: eg, `**/*.exe` instead of `**.exe`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 # ... except all files that have a dot of course ;-)
 !**/*.*
 nimcache
-**gmon.out
+**/gmon.out
 # on windows: ignore all generated files
-**.exe 
-**.ilk 
-**.pdb
+**/*.exe 
+**/*.ilk 
+**/*.pdb


### PR DESCRIPTION
`**` should only appear as a path component: eg, `**/*.exe` instead of `**.exe`

for eg:
`rg -t nim some_pattern` reports:
```
./zero-functional/.gitignore: line 6: error parsing glob '**gmon.out': invalid use of **; must be one path component
./zero-functional/.gitignore: line 8: error parsing glob '**.exe': invalid use of **; must be one path component
```
after PR, no more error
(using ripgrep rg)