### PR TITLE
Feature/#53 rework combinations

### DIFF
--- a/test.nim
+++ b/test.nim
@@ -139,10 +139,10 @@ zf_inline removeDoubles():
     # this is the tricky one: remove later elements that already are in the list
     # this actually translates in the inner for loop of combinations as:
     # if idx[0] > idx[1] and it[0] == it[1]: break
-    takeWhile(not(it.item[0] == it.item[1] and it.idx[0] > it.idx[1])) 
+    takeWhile(not(it.elem[0] == it.elem[1] and it.idx[0] > it.idx[1])) 
     # go back to the original elements
     filter(it.idx[0] == it.idx[1]) 
-    map(it.item[0])
+    map(it.elem[0])
 
 proc inlineRemove*(ext: ExtNimNode) {.compileTime.} =
   ## remove function that removes elements from a collection
@@ -521,7 +521,7 @@ suite "valid chains":
     proc abs1(a: int, b: int) : bool = abs(a-b) == 1 
     let b = items -->
       indexedCombinations().
-      filter(abs1(it.item[0], it.item[1])).
+      filter(abs1(it.elem[0], it.elem[1])).
       map(it.idx) 
     check(b == @[[0, 2], [2, 5], [3, 4]])
     check(b --> all(abs1(items[it[0]], items[it[1]])))
@@ -529,7 +529,7 @@ suite "valid chains":
     # the same again, but store it to a new list
     let c = items -->
       indexedCombinations().
-      filter(abs1(it.item[0], it.item[1])).
+      filter(abs1(it.elem[0], it.elem[1])).
       map(it.idx).
       to(list)
     
@@ -546,9 +546,7 @@ suite "valid chains":
 
     # check indexedCombinations with 2 different collections
     check([11,22] --> indexedCombinations([33,44]) == 
-      @[(idx: [0, 0], item: [11, 33]), (idx: [0, 1], item: [11, 44]), (idx: [1, 0], item: [22, 33]), (idx: [1, 1], item: [22, 44])])
-
-
+      @[(idx: [0, 0], elem: [11, 33]), (idx: [0, 1], elem: [11, 44]), (idx: [1, 0], elem: [22, 33]), (idx: [1, 1], elem: [22, 44])])
   
   test "rejected flatten":
     # some things are not possible or won't compile
@@ -811,10 +809,10 @@ suite "valid chains":
               # this is the tricky one: remove later elements that already are in the list
               # this actually translates in the inner for loop of combinations as:
               # if idx[0] > idx[1] and it[0] == it[1]: break
-              takeWhile(not(it.idx[0] > it.idx[1] and it.item[0] == it.item[1])). 
+              takeWhile(not(it.idx[0] > it.idx[1] and it.elem[0] == it.elem[1])). 
               # go back to the original elements
               filter(it.idx[0] == it.idx[1]). 
-              map(it.item[0])  ==
+              map(it.elem[0])  ==
                                @[1,2,3,4])
   ## Example that uses own extensions: `average`, `intersect`, `inc` and `filterNot`. 
   ## `intersect` uses the same implementation as in the previous test.

--- a/test.nim
+++ b/test.nim
@@ -109,24 +109,23 @@ zf_inline average():
       result = sum / float(countIdx)
 
 zf_inline intersect(_):
-# intersect from the example test case below:
+# get all elements that are contained in all collections given as parameters
+# this function is built similar to the test case below:
 #   combinations(b,squaresPlusOne()). # combine all elements of a,b...
-#   map(c.it). # get the iterator contents of each combination (indices not relevant here)
 #   filter(it[0] == it[1] and it[0] == it[2]). # this is the trickier one
 #   map(it[0])
 
   pre:
-    let c = newIdentNode(zfCombinationsId)
-    # build the it[0] == it[1] and ... chain
+    # first build the it[0] == it[1] and ... chain
     var chain = quote: true
     for i in (1..<ext.node.len):
       # ... and it[0] == it[i]
       chain = quote:
-        `chain` and (it[0] == it[`i`])
+        `chain` and (it[0] == it[`i`]) # compare first element to all others
 
   delegate:
-    combinations(_) # all arguments of intersect are delegated to combinations
-    map(c.it)
+    # all arguments of intersect are delegated to combinations
+    combinations(_)
     filter(chain)
     map(it[0])
 
@@ -134,17 +133,16 @@ zf_inline removeDoubles():
 # remove double elements. Code taken from example "remove doublettes" below
   pre:
     let listRef = ext.listRef
-    let c = newIdentNode(zfCombinationsId)
   delegate:
     # this actually only works only on th eoriginal list / iterator
-    combinations(listRef) # combine with itself - all elements
+    indexedCombinations(listRef) # combine with itself - all elements
     # this is the tricky one: remove later elements that already are in the list
     # this actually translates in the inner for loop of combinations as:
-    # if c.idx[0] > c.idx[1] and c.it[0] == c.it[1]: break
-    takeWhile(not(c.it[0] == c.it[1] and c.idx[0] > c.idx[1])) 
+    # if idx[0] > idx[1] and it[0] == it[1]: break
+    takeWhile(not(it.item[0] == it.item[1] and it.idx[0] > it.idx[1])) 
     # go back to the original elements
-    filter(c.idx[0] == c.idx[1]) 
-    map(c.it[0])
+    filter(it.idx[0] == it.idx[1]) 
+    map(it.item[0])
 
 proc inlineRemove*(ext: ExtNimNode) {.compileTime.} =
   ## remove function that removes elements from a collection
@@ -515,24 +513,24 @@ suite "valid chains":
     check((e --> map(it) --> to(seq[string])) == @["2.4", "4.8"])
     check((e --> map($it) --> to(seq)) == @["2.4", "4.8"])
     check((e --> map(it) --> to(seq)) == @["2.4", "4.8"])
-
+  
   test "combinations":
     ## get indices of items where the difference of the elements is 1
     let items = @[1,5,2,9,8,3,11]
     # ----------- 0 1 2 3 4 5 6
     proc abs1(a: int, b: int) : bool = abs(a-b) == 1 
     let b = items -->
-      combinations().
-      filter(abs1(c.it[0], c.it[1])).
-      map(c.idx) 
+      indexedCombinations().
+      filter(abs1(it.item[0], it.item[1])).
+      map(it.idx) 
     check(b == @[[0, 2], [2, 5], [3, 4]])
     check(b --> all(abs1(items[it[0]], items[it[1]])))
 
     # the same again, but store it to a new list
     let c = items -->
-      combinations().
-      filter(abs1(c.it[0], c.it[1])).
-      map(c.idx).
+      indexedCombinations().
+      filter(abs1(it.item[0], it.item[1])).
+      map(it.idx).
       to(list)
     
     # check that all items in the list and the seq are the same
@@ -541,11 +539,17 @@ suite "valid chains":
     # check that only `2` is in both `a` and `b`
     let both = a_array --> 
       combinations(b_array). # build combinations with b
-      map((it_a, it_b) = c.it). # define the iterators a it_a (from a) and it_b
+      map((it_a, it_b) = it). # define the iterators a it_a (from a) and it_b
       filter(it_a == it_b). # restrict to elements in both a and b
       map(it_a) # it is still ((it_a, it_b)) => restrict to it_a 
-    check (both == @[2])  
+    check (both == @[2])
 
+    # check indexedCombinations with 2 different collections
+    check([11,22] --> indexedCombinations([33,44]) == 
+      @[(idx: [0, 0], item: [11, 33]), (idx: [0, 1], item: [11, 44]), (idx: [1, 0], item: [22, 33]), (idx: [1, 1], item: [22, 44])])
+
+
+  
   test "rejected flatten":
     # some things are not possible or won't compile
     let fArray = [[1,2,3], [4,5,6]]
@@ -559,9 +563,9 @@ suite "valid chains":
     # comparison seq to array works now - but automatically converting to an array 
     # needs the array size to prevent a runtime error overwriting the bounds. 
     # reject(fArray --> flatten() --> to(array) == [1,2,3,4,5,6]) 
-    accept((fArray --> flatten() --> to(array[6,int])) == [1,2,3,4,5,6])
+    check((fArray --> flatten() --> to(array[6,int])) == [1,2,3,4,5,6])
     # if the array is too big, the array is filled with default zero
-    accept((fArray --> flatten() --> to(array[8,int])) == [1,2,3,4,5,6,0,0]) 
+    check((fArray --> flatten() --> to(array[8,int])) == [1,2,3,4,5,6,0,0]) 
     # if the array is too small we get a runtime error
 
     # list is flattened to seq by default
@@ -599,7 +603,8 @@ suite "valid chains":
     check(gg() --> map(parseInt(it)) --> map(1.5 * float(it))[2] == 4.5)
     check(a --> index(it == -4) + 1 == 3)
     check(@[@[1,2], @[3,4]] --> flatten() == @[1,2,3,4])
-    check(@[11,2,7,3,4] --> combinations() --> filter(abs(c.it[1]-c.it[0]) == 1) --> map(c.idx) == @[[1,3],[3,4]])
+    check(@[11,2,7,3,4] --> indexedCombinations() --> 
+      map((index,item) = it) --> filter(abs(item[1]-item[0]) == 1) --> map(index) == @[[1,3],[3,4]])
     check(@[1,2,3] --> map($it) --> to(list) is DoublyLinkedList[string])
   
   test "simple iterator":
@@ -627,8 +632,8 @@ suite "valid chains":
     accept(d --> to(seq) == @[2,4,6])
 
     reject(zip(si,si2) --> map($it) != nil, "need to provide an own implementation for mkIndexable(SimpleIter)") # zip also needs the [] operator
-    reject2(si --> combinations() --> all(c.it[0] < c.it[1]), "Only index with len types supported for combinations")
-    accept(d --> combinations() --> map(c.it) --> all(it[0] < it[1]))
+    reject2(si --> combinations() --> all(it[0] < it[1]), "Only index with len types supported for combinations")
+    accept(d --> combinations() --> all(it[0] < it[1]))
 
   test "zip with simpleIter":
     let si = initSimpleIter()
@@ -665,10 +670,10 @@ suite "valid chains":
 
   test "closure parameters":
     # x is an illegal capture - so this will be rejected
-    when not defined(js):
-      reject:
-        proc chkVarError(x: var seq[int], y: int): seq[int] =
-          result = x --> filter(it != y) 
+    # currently this is not detected as a `reject` - but still is rejected by the compiler
+    reject2:
+      proc chkVarError(x: var seq[int], y: int): seq[int] =
+        result = x --> filter(it != y) 
 
     proc chkVar(x: var seq[int], y: int): seq[int] =
       let x = x # assigning x to a constant will work
@@ -685,7 +690,7 @@ suite "valid chains":
       result = x --> map($it)
 
     var s = @[1,2,3]
-    check(chkVar(s, 2) == @[1,3]) # - strangely this doesn't work any more - seems to be a problem of defining an iterator in the anonymous function in a local function (?!)
+    check(chkVar(s, 2) == @[1,3])
     check(chkVarFor(s) == 6)
     check(chkConversion(s) == @["1","2","3"])
 
@@ -794,7 +799,6 @@ suite "valid chains":
 
     let intersect = 
       a() --> combinations(b,squaresPlusOne()). # combine all elements of a,b and squarePlusOne
-              map(c.it). # get the iterator contents of each combination (indices not relevant here)
               filter(it[0] == it[1] and it[0] == it[2]). # get all combinations where the elements of each collection are equal
               map(it[0]). # and use the first element
               to(seq[int]) # output type with a() on left side has to be supplied
@@ -803,16 +807,15 @@ suite "valid chains":
   ## Remove double entries from a collection. Could be used to extend `intersect`.
   test "complex function remove doublettes":
     let a = @[1,2,1,1,3,2,1,1,4]
-    check(a --> combinations(a). # combine with itself - all elements
+    check(a --> indexedCombinations(a). # combine with itself - all elements
               # this is the tricky one: remove later elements that already are in the list
               # this actually translates in the inner for loop of combinations as:
-              # if c.idx[0] > c.idx[1] and c.it[0] == c.it[1]: break
-              takeWhile(not(c.idx[0] > c.idx[1] and c.it[0] == c.it[1])). 
+              # if idx[0] > idx[1] and it[0] == it[1]: break
+              takeWhile(not(it.idx[0] > it.idx[1] and it.item[0] == it.item[1])). 
               # go back to the original elements
-              filter(c.idx[0] == c.idx[1]). 
-              map(c.it[0])  ==
+              filter(it.idx[0] == it.idx[1]). 
+              map(it.item[0])  ==
                                @[1,2,3,4])
-
   ## Example that uses own extensions: `average`, `intersect`, `inc` and `filterNot`. 
   ## `intersect` uses the same implementation as in the previous test.
   test "register own extension":
@@ -967,7 +970,8 @@ suite "valid chains":
     check(x --> (it_x) --> exists(y --> (it_y) --> exists(it_x == it_y)))
     # alternative (maybe nicer to read) bracketing
     check((x --> it_x) --> exists((y --> it_y) --> exists(it_x == it_y)))
-    
+    check((a --> x) --> exists((b --> y) --> exists(x == y)))
+
     let b = x.zfun(a):
       exists:
         z.zfun(b):

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -2,7 +2,6 @@ import macros, options, sets, lists, typetraits, strutils, tables
 
 const zfIteratorVariableName* = "it"
 const zfAccuVariableName* = "a"
-const zfCombinationsId* = "c"
 const zfIndexVariableName* = "idx"
 const zfListIteratorName* = "__itlist__"
 const zfMinHighVariableName* = "__minHigh__"
@@ -39,7 +38,7 @@ type
     ## All available commands.
     ## 'to' - is a virtual command
     all, combinations, count, createIter, drop, dropWhile, exists, filter, find, flatten, fold, foreach,
-    index, indexedFlatten, indexedMap, indexedReduce, map, reduce, sub, zip, take, takeWhile, to, uniq
+    index, indexedCombinations, indexedFlatten, indexedMap, indexedReduce, map, reduce, sub, zip, take, takeWhile, to, uniq
 
   ReduceCommand {.pure.} = enum
     ## additional commands that operate as reduce command
@@ -90,20 +89,20 @@ type
     a.len() is int
     a[int] is T
     for it in a:
-      type(it) is T
+      it is T
 
   Iterable*[T] = concept a
     for it in a:
-      type(it) is T
+      it is T
 
   Appendable*[T] = concept a, var b
     for it in a:
-      type(it) is T
+      it is T
     b.append(T)
 
   Addable*[T] = concept a, var b
     for it in a:
-      type(it) is T
+      it is T
     b.add(T)
 
 
@@ -152,15 +151,27 @@ proc zfAddSequenceHandlers*(seqHandlers: seq[string]) {.compileTime.} =
 proc zfAddSequenceHandlers*(seqHandlers: varargs[string]) {.compileTime.} =
   SEQUENCE_HANDLERS.incl(seqHandlers.toSet)
 
-## Find a node given its kind and - optionally - its content.
-proc findNode*(node: NimNode, kind: NimNodeKind, content: string = "") : NimNode =
-  if node.kind == kind and (content.len == 0 or content == $node):
+## check if the discriminator function is valid for the node or one of its children (depth-first). 
+proc checkNode(node: NimNode, discriminator: proc (n: NimNode): bool): NimNode =
+  if (discriminator(node)):
     return node
   for child in node:
-    let res = child.findNode(kind, content)
+    let res = child.checkNode(discriminator)
     if res != nil:
       return res
   return nil
+
+proc findNode*(node: NimNode, kind: NimNodeKind, content: string = "") : NimNode =
+  ## Find a node given its kind and - optionally - its content.
+  proc hasNodeWithKind(node: NimNode): bool =
+    result = (node.kind == kind and (content.len == 0 or content == $node))
+  return node.checkNode(hasNodeWithKind)
+
+proc findDefinition*(node: NimNode, label: string, kind = nnkLetSection): NimNode = 
+  ## Find the definition of a constant or variable
+  proc hasDefinition(node: NimNode): bool =
+    result = (node.kind == kind and node.findNode(nnkIdent, label) != nil)
+  return node.checkNode(hasDefinition)
 
 macro idents(args: varargs[untyped]): untyped =
   ### shortcut implementation
@@ -524,7 +535,7 @@ macro zfAddItemChk*(resultIdent: untyped, idxIdent: untyped, addItem: untyped, t
     elif compiles(zfAddItemConvert(`resultIdent`, `idxIdent`, `addItem`)):
       zfAddItemConvert(`resultIdent`, `idxIdent`, `addItem`)
       # extra cast - see bug https://github.com/nim-lang/Nim/issues/7375
-      when bool(`autoConvert`) == false:
+      when not bool(`autoConvert`):
         warning("Type " & $`addItem`.type & " was automatically converted to " & $`resultType` &
                 "\nTo remove this warning either set second parameter of `to` to true or adapt the result type.")
     else:
@@ -743,13 +754,16 @@ proc zeroParse(header: NimNode, body: NimNode): NimNode =
       # register iterator as sequence handler
       zfAddSequenceHandlers(if isCall: funName[0..funName.len-9] else: funName)
 
-    if body.findNode(nnkIdent, zfIndexVariableName) != nil:
+    # check if idx is used but not defined in the body section
+    if (body.findNode(nnkIdent, zfIndexVariableName) != nil):
       idents(idxIdent)
-      letSection.add quote do:
-        let `idxIdent` = newIdentNode(`zfIndexVariableName`)
-        discard(`idxIdent`)
-        `ext`.needsIndex = true
-      quotedVars[zfIndexVariableName] = "idxIdent"
+      if (body.findDefinition(zfIndexVariableName) == nil):
+        letSection.add quote do:
+          # add a definition for idx
+          let `idxIdent` = newIdentNode(`zfIndexVariableName`)
+          discard(`idxIdent`)
+          `ext`.needsIndex = true
+        quotedVars[zfIndexVariableName] = "idxIdent"
 
     if (not hasPre and body[0].label != "delegate") or body.len != 2 or body[1].label != "delegate":
       # replace it in 'it = ...' with `nextIt` and create the next iterator
@@ -912,7 +926,7 @@ proc inlineMap*(ext: ExtNimNode) {.compileTime.} =
         # let ((a,b) = c) is translated to 
         # let a = c[0]
         # let b = c[1]
-        let vt = newIdentDefs(varName, newEmptyNode(), nnkBracketExpr.newTree().add(v[1]).add(newIntLitNode(idx)))
+        let vt = newIdentDefs(varName, newEmptyNode(), nnkBracketExpr.newTree(v[1]).add(newIntLitNode(idx)))
         ext.node.add(vt)
     else:
       # just the "normal" definition (a = b)
@@ -931,7 +945,7 @@ proc inlineMap*(ext: ExtNimNode) {.compileTime.} =
 
 zf_inline indexedMap(f):
   loop:
-    let it = (idx, f)
+    let it = (idx: idx, item: f)
 
 ## Implementation of the 'filter' command.
 ## The trailing commands execution depend on the filter condition to be true.
@@ -962,16 +976,23 @@ zf_inline uniq():
 ## Implementation of the 'flatten' command.
 ## E.g. @[@[1,2],@[3],@[4,5,6]] --> flatten() == @[1,2,3,4,5,6]
 zf_inline flatten():
+  pre:
+    # `idx` has to be re-defined for the new collection
+    # make sure `idx` is really named `idx` and not to an auto variable
+    idents(idx(zfIndexVariableName))
   init:
     var idxFlatten = -1
   loop:
     for flattened in it:
       let it = flattened
       idxFlatten += 1
-      let idx = idxFlatten
-      discard(idx)
+      let `idx` = idxFlatten
+      discard(`idx`)
 
 zf_inline indexedFlatten():
+  pre:
+    # same as in flatten
+    idents(idx(zfIndexVariableName))
   init:
     var idxFlatten = -1
   loop:
@@ -979,9 +1000,9 @@ zf_inline indexedFlatten():
     for flattened in it:
       idxInner += 1
       idxFlatten += 1
-      let it = (idxInner, flattened)
-      let idx = idxFlatten
-      discard(idx)
+      let it = (idx: idxInner, item: flattened)
+      let `idx`  = idxFlatten
+      discard(`idx`)
 
 ## Implementation of the `takeWhile` command.
 ## `takeWhile(cond)` : Take all elements as long as the given condition is true.
@@ -1203,7 +1224,7 @@ proc inlineReduce(ext: ExtNimNode) {.compileTime.} =
           let `nextIt` = (oldValue, it) # reduce
           let newValue = op
           if not (oldValue == newValue):
-            result = (idx, newValue) # propagate new value with idx
+            result = (idx: idx, item: newValue) # propagate new value with idx
       endLoop:
         if initAccu:
           result[0] = -1 # we actually do not have a result: set index to -1
@@ -1224,8 +1245,6 @@ proc inlineReduce(ext: ExtNimNode) {.compileTime.} =
 ## Implementation of the 'combinations' command.
 ## Each two distinct elements of the input list are combined to one element.
 proc inlineCombinations(ext: ExtNimNode) {.compileTime.} =
-  ext.needsIndex = true
-  idents(idxIdent(zfIndexVariableName), itCombo(zfCombinationsId))
   if ext.node.len == 1:
     if ext.isListType():
       zf_inline_call combinations():
@@ -1233,10 +1252,8 @@ proc inlineCombinations(ext: ExtNimNode) {.compileTime.} =
           let itList = newIdentNode(zfListIteratorName)
         loop:
           var itListInner = itList.next
-          var idxInner = idx
           while itListInner != nil:
-            let `itCombo` = createCombination([it, itListInner.value], [idx, idxInner])
-            idxInner += 1
+            let it = [it, itListInner.value]
             itListInner = itListInner.next
             nil
     else:
@@ -1248,14 +1265,61 @@ proc inlineCombinations(ext: ExtNimNode) {.compileTime.} =
             static:
               zfFail("Only index with len types supported for combinations")
           for idxInner in idx+1..<listRef.len():
-            let `itCombo` = createCombination([listRef[idx], listRef[idxInner]], [idx, idxInner])
+            let it = [listRef[idx], listRef[idxInner]]
             nil
   else: # combine with other collections
     var code = nnkStmtList.newTree()
     var root = code
     var itIdent = ext.prevItNode()
-    let iterators = nnkBracket.newTree().add(itIdent)
-    let indices = nnkBracket.newTree().add(idxIdent)
+    let iterators = nnkBracket.newTree(itIdent)
+    var idx = 1
+    while idx < ext.node.len:
+      itIdent = ext.nextItNode()
+      iterators.add(itIdent)
+      let listRef = ext.node[idx]
+      idx += 1
+      code.add quote do:
+        for `itIdent` in `listRef`:
+          nil
+      code = code.getStmtList()
+    let nextIt = ext.nextItNode()
+    code.add quote do:
+      let `nextIt` = `iterators`
+      nil
+    ext.node = root
+
+proc inlineIndexedCombinations(ext: ExtNimNode) {.compileTime.} =
+  idents(idxIdent(zfIndexVariableName))
+  if ext.node.len == 1:
+    if ext.isListType():
+      zf_inline_call indexedCombinations():
+        pre:
+          let itList = newIdentNode(zfListIteratorName)
+        loop:
+          var itListInner = itList.next
+          var idxInner = idx
+          while itListInner != nil:
+            let it = (idx: [idx, idxInner], item: [it, itListInner.value])
+            idxInner += 1
+            itListInner = itListInner.next
+            nil
+    else:
+      zf_inline_call indexedCombinations():
+        pre:
+          let listRef = ext.listRef
+        loop:
+          when not (listRef is FiniteIndexableLenIter):
+            static:
+              zfFail("Only index with len types supported for combinations")
+          for idxInner in idx+1..<listRef.len():
+            let it = (idx: [idx,idxInner], item: (listRef[idx], listRef[idxInner]))
+            nil
+  else: # combine with other collections
+    var code = nnkStmtList.newTree()
+    var root = code
+    var itIdent = ext.prevItNode()
+    let iterators = nnkBracket.newTree(itIdent)
+    let indices = nnkBracket.newTree(idxIdent)
     var idx = 1
     while idx < ext.node.len:
       itIdent = ext.nextItNode()
@@ -1270,10 +1334,13 @@ proc inlineCombinations(ext: ExtNimNode) {.compileTime.} =
           `idxInner` += 1
           nil
       code = code.getStmtList()
+    let nextIt = ext.nextItNode()
     code.add quote do:
-      let `itCombo` = createCombination(`iterators`, `indices`)
+      let `nextIt` = (idx: `indices`, item: `iterators`)
       nil
     ext.node = root
+
+
 
 macro genTupleSeqCalls(maxTupleSize: static[int]): untyped =
   ## generates the procs initTupleSeq and addToTupleSeq needed for the split command
@@ -1976,7 +2043,7 @@ proc iterHandler(args: NimNode, td: string, debugInfo: string): NimNode {.compil
       # the actual outer loop is created last - so insert the functions here
       newCode.add(codeStart)
       # and set the current outer loop as new codeStart
-      codeStart = nnkStmtList.newTree().add(ext.node)
+      codeStart = nnkStmtList.newTree(ext.node)
       index = oldIndex
     else:
       code.add(ext.node)
@@ -2143,7 +2210,7 @@ proc delegateMacro(a: NimNode, b1:NimNode, td: string, debugInfo: string): NimNo
   let args = nnkArgList.newTree()
   # re-arrange shortcut expression of (a --> itName) to alternative shortcut a --> (itName)
   if a.kind == nnkPar and a[0].kind == nnkInfix and a[0][0].label.startswith(zfArrow):
-    args.add(nnkArgList.newTree().add(a[0][1])).add(newPar(a[0][2]))
+    args.add(nnkArgList.newTree(a[0][1])).add(newPar(a[0][2]))
   else:
     args.add(a)
   for it in m:


### PR DESCRIPTION
* rework of combinations function
* `indexed` functions return a named tuple (idx: index, elem: iterated_elem) now instead of an unnamed one
* small fix regarding `idx`
* update of documentation