### PR TITLE
Fix for current devel, removes `untyped` return type for iterators

### DIFF
--- a/test.nim
+++ b/test.nim
@@ -949,8 +949,8 @@ suite "valid chains":
     let a1 = @[1,2,3]
     check($(a --> zip(a, a1)) == "@[(a0: 2, a1: 2, a12: 1), (a0: 8, a1: 8, a12: 2), (a0: -4, a1: -4, a12: 3)]")
     # using other expressions does not yield named tuples however
-    check($(a --> zip(@[1,2])) == "@[(Field0: 2, Field1: 1), (Field0: 8, Field1: 2)]")
-    check($(@[1,2] --> zip(a)) == "@[(Field0: 1, Field1: 2), (Field0: 2, Field1: 8)]")    
+    check($(a --> zip(@[1,2])) == "@[(2, 1), (8, 2)]")
+    check($(@[1,2] --> zip(a)) == "@[(1, 2), (2, 8)]")
 
   test "uniq":
     check(@[ 1, 2, 2, 2, 2, 3, 4, 4, 4, 5 ] --> uniq() == @[ 1, 2, 3, 4, 5 ]);

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -80,10 +80,12 @@ type
   FiniteIndexable*[T] = concept a
     a.low() is int
     a.high() is int
+    a[int] is T
     a[int]
 
   FiniteIndexableLen*[T] = concept a
     a.len() is int
+    a[int] is T
     a[int]
 
   FiniteIndexableLenIter*[T] = concept a

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -298,17 +298,17 @@ proc createCombination*[A,T](it: array[A,T], idx: array[A,int]): Combination[A,T
   result = Combination[A,T](it: it, idx: idx)
 
 ## iterator over tuples (needed for flatten to work on tuples, e.g. from zipped lists)
-iterator items*[T: tuple](a:T) : untyped =
+iterator items*[T: tuple](a:T) : auto =
   for i in a.fields:
     yield i
 
 ## iterate over concept FiniteIndexable
-iterator items*[T: FiniteIndexable](f:T) : untyped =
+iterator items*[T](f: FiniteIndexable[T]) : T =
   for i in f.low()..f.high():
     yield f[i]
 
 ## iterate over concept FiniteIndexable
-iterator items*[T: FiniteIndexableLen](f:T) : untyped =
+iterator items*[T](f: FiniteIndexableLen[T]) : T =
   for i in 0..<f.len():
     yield f[i]
 

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -300,6 +300,8 @@ proc createCombination*[A,T](it: array[A,T], idx: array[A,int]): Combination[A,T
   result = Combination[A,T](it: it, idx: idx)
 
 ## iterator over tuples (needed for flatten to work on tuples, e.g. from zipped lists)
+## NOTE: this iterator can only be used for tuples containing elements of the
+## same type! Otherwise it errors at compile time.
 iterator items*[T: tuple](a:T) : auto =
   for i in a.fields:
     yield i


### PR DESCRIPTION
Recently support for procs and iterators returning `untyped` was removed on devel. This PR changes the 3 iterators relying on that feature.

The two iterators working on `FiniteIndexable` and `FiniteIndexableLen` are straight forward, because the collection should contain a single type as far as I can tell anyways (otherwise it wouldn't be a concept of a single generic, no?)
I only added the `a[int] is T` fields to the two concepts to get rid of some (but not all unfortunately) now appearing `T is declared but not used` hints. I'm not familiar enough with concepts to know why that hint still happens sometimes though. :/

The `items` iterator for tuples is more troublesome. For now I just replaced the `untyped` with an `auto`. This of course means that this iterator can only be used on tuples, where all  fields have the same type. But again, as far as I can tell, it's only used to flatten tuples into sequences, which means the data types must match in any case.
I suppose an alternative approach would be a replacement by a macro that unrolls the for loop over the tuple. 

Also the rendering of nameless tuples apparently changed recently, such that the `Field0` etc. names are not shown anymore.