### PR TITLE
fix zero_functional for https://github.com/nim-lang/Nim/pull/18050

### DIFF
--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -122,7 +122,7 @@ type
       it is T
 
   Iterable*[T] = concept a
-    for it in a:
+    for it in items(a):
       it is T
 
   Appendable*[T] = concept a, var b


### PR DESCRIPTION
unblocks https://github.com/nim-lang/Nim/pull/18050 which fixes the long-standing generic sandwich problem in nim

this is forward and backward compatible.

the problem is that after https://github.com/nim-lang/Nim/pull/18050, `for it in a` would hit https://github.com/nim-lang/Nim/issues/11167; this PR fixes this.

here's the that that was triggering the problem: items is being defined here:
```nim
    let items = @[1, 5, 2, 9, 8, 3, 11]
    # ----------- 0..1..2..3..4..5..6
    #------------ ^.....^........^
    proc abs1(a: int, b: int): bool = abs(a-b) == 1
    let b = items -->
      indexedCombinations().
      filter(abs1(it.elem[0], it.elem[1])).
      map(it.idx)
```

## reduced case
(after a painful reduction involving macros recursively calling macros several layers deep):
```nim
when defined case11:
  type Iterable = concept a
    for it in a: discard # fails (hits https://github.com/nim-lang/Nim/issues/11167)
     # for it in items(a): discard # works (avoids https://github.com/nim-lang/Nim/issues/11167)
  proc foo2[T](a: T): Iterable = @[10,11]
  let items = "abc" # confuses the symbol binding in the implicit items in `for it in a`
  let b = foo2(3)
```
alternative reduced case without `concept`:
```nim
when defined case13:
  proc baz(a: auto) =
    for it in a: discard # fails with https://github.com/nim-lang/Nim/pull/18050
      # (would hit https://github.com/nim-lang/Nim/issues/11167)
    # for it in items(a): discard # works
  proc foo2[T](a: T) =
    baz(a)
  let items = "abc"
  foo2(@[1,2])
```

note: in this case, it would work because items overloads, instead of hides:
```nim
when defined case12:
  # works
  proc baz(a: auto) =
    for it in a: discard
  proc foo2[T](a: T) = baz(a)
  proc items(x: float): auto = 12
  proc items(x: float32): auto = 13
  foo2(@[1,2])
```
