### PR TITLE
Fix `enumerate` , undeprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Table of Contents
   * [all](#all)
   * [index](#index)
   * [indexedMap](#indexedmap)
+  * [enumerate](#enumerate)
   * [fold](#fold)
   * [reduce](#reduce)
     + [max](#max)
@@ -361,14 +362,14 @@ var n = zip(a, b, c) -->
             all(it > 4)
 ```
 
-### enumerate (deprecated)
+### enumerate
 
-Note: enumerate has been deprecated since it is defined in the nim standard library now and this will interfere with zero-functional.
+Prepends the index to the value of the current iteration (unlike the `indexedMap`, which indexes the initial collection/iteration) and generates a named tuple `(idx: index, elem: it)` for each element in the iterable. Does not take any parameters.
 
-Is similar to `indexedMap` and to [`enumerate`](https://docs.python.org/3/library/functions.html#enumerate) in python. It does not take any parameters and just works on the current collection adding the index of the current element.
+Is similar to [`enumerate`](https://docs.python.org/3/library/functions.html#enumerate) in Python or [`enumerate`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.enumerate) in Rust.
 
 ```nim
-@[8, 11, 12] --> enumerate() == @[(0,8), (1,11), (2,12)] 
+0..10 --> filter(it mod 2 == 0).enumerate().map(it.idx) == @[0, 1, 2, 3, 4, 5]
 ```
 
 ### fold

--- a/test.nim
+++ b/test.nim
@@ -112,7 +112,7 @@ zfInline average():
 zfInline intersect(_):
 # get all elements that are contained in all collections given as parameters
 # this function is built similar to the test case below:
-#   combinations(b,squaresPlusOne()).  
+#   combinations(b,squaresPlusOne()).
   pre:
     # first build the it[0] == it[1] and ... chain
     var chain = quote: true
@@ -295,7 +295,7 @@ suite "valid chains":
     check(not (a --> all(it > 0)))
 
   test "all with changed type":
-    check(a --> map(`$`) --> all(it.len > 0)) 
+    check(a --> map(`$`) --> all(it.len > 0))
 
   test "index":
     check((a --> index(it > 4)) == 1)
@@ -328,7 +328,7 @@ suite "valid chains":
 
   test "map with fold":
     check((a --> map(g(it)) --> fold(0, a + it)) == 10)
-    check((a --> map(`$`) --> fold("", a & it)) == "28-4")    
+    check((a --> map(`$`) --> fold("", a & it)) == "28-4")
 
   test "map with changed type":
     check((a --> mapSeq($it)) == @["2", "8", "-4"])
@@ -410,7 +410,7 @@ suite "valid chains":
     check((aArray --> indexedMap(it)) == @[(0, 2), (1, 8), (2, -4)])
     check((aArray --> indexedMap(it + 2) --> map(it.idx + it.elem)) ==
         @[4, 11, 0])
-        
+
   test "array enumerate":
     check((aArray --> enumerate()) == @[(0, 2), (1, 8), (2, -4)])
     check((aArray --> enumerate() --> map(it.idx + it.elem + 2)) ==
@@ -541,7 +541,7 @@ suite "valid chains":
     check((e --> find(false)) == none(int))
     check((e --> find(true)) == none(int))
     check((e --> index(false)) == -1)
-    check((e --> index(true)) == -1)    
+    check((e --> index(true)) == -1)
     check((e --> map(it * 2)) == res)
     check((e --> filter(it > 0) --> map(it * 2)) == res)
 
@@ -554,7 +554,7 @@ suite "valid chains":
     check((e --> map($it) --> index(it != "123")) == -1)
     check((e --> map($it)) == res2)
     check((e --> map($it) --> filter(it.len > 0) --> map(it & it)) == res2)
- 
+
   test "flatten":
     let f = @[@[1, 2, 3], @[4, 5], @[6]]
     check(f --> flatten() == @[1, 2, 3, 4, 5, 6])
@@ -669,7 +669,7 @@ suite "valid chains":
   test "SinglyLinkedList reversing elements":
     var l = a --> map(it) --> to(SinglyLinkedList)
     check(l --> map(it).to(seq) == @[-4, 8, 2])
-  
+
   test "map with operator access":
     proc gg(): seq[string] =
       @["1", "2", "3"]
@@ -882,7 +882,7 @@ suite "valid chains":
     let intersect =
       a() --> combinations(b, squaresPlusOne()). # combine all elements of a,b and squarePlusOne
         # get all combinations where the elements of each collection are equal
-        filter(it[0] == it[1] and it[0] == it[2]).  
+        filter(it[0] == it[1] and it[0] == it[2]).
         map(it[0]).  # and use the first element
         to(seq[int]) # output type with a() on left side has to be supplied
     check(intersect == @[5, 17])
@@ -1110,4 +1110,6 @@ suite "valid chains":
     check(m['e'] == @[("1", "one"), ("3", "three")])
     check(m['o'] == @[("2", "two")])
 
+  test "enumerate iteration":
+    check(0..10 --> filter(it mod 2 == 0).enumerate().map(it.idx) == @[0, 1, 2, 3, 4, 5])
 

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -256,7 +256,7 @@ proc replace(node: NimNode, searchNode: NimNode, replNode: NimNode,
       elif all:
         child.replace(searchNode, replNode, all)
 
-proc getNilStmtParent(node: NimNode): (NimNode, int) = 
+proc getNilStmtParent(node: NimNode): (NimNode, int) =
   result = (nil, -1)
   var n = node
   for i in countdown(n.len-1, 0):
@@ -1092,14 +1092,14 @@ proc inlineMap*(ext: ExtNimNode) {.compileTime.} =
     else:
       # just the "normal" definition (a = b)
       ext.node.add(newIdentDefs(v[0], newEmptyNode(), v[1]))
-    
+
     if not isInternal: # leave out definitions that access it or idx directly
       # set next iterator
       let f = v[0] # set 'it' to the previously assigned value / 'it' might also be consequently used
       ext.node = newStmtList(ext.node).add quote do:
         let it = `f`
         discard(it) # iterator might not be used
-  
+
   # check for recursive arrow in the map: if used assign another iterator - prevents capturing error of outer iterator
   elif kind == nnkInfix and (ext.node[1][0].label == zfArrow or ext.node[1][0].label == zfArrowDbg):
     zfInlineCall map(f):
@@ -1115,7 +1115,7 @@ proc inlineMap*(ext: ExtNimNode) {.compileTime.} =
           when compiles(f(it)):
             f(it)
           else:
-            f 
+            f
   else:
     zfInlineCall map(f):
       loop:
@@ -1126,8 +1126,11 @@ zfInline indexedMap(f):
     let it = mkIndexedResult(idx, f)
 
 zfInline enumerate():
+  init:
+    var iterCounter = 0
   loop:
-    let it = mkIndexedResult(idx, it)
+    let it = (idx: iterCounter, elem: it)
+    iterCounter.inc()
 
 ## Implementation of the 'filter' command.
 ## The trailing commands execution depend on the filter condition to be true.
@@ -1357,7 +1360,7 @@ proc inlineForeach*(ext: ExtNimNode) {.compileTime.} =
     adaptedExpression = nnkAsgn.newTree(adaptedExpression[0], adaptedExpression[1])
   ext.node = newStmtList().add quote do:
     `adaptedExpression`
-  
+
 ## Implementation of the 'index' command.
 ## Returns the index of the element in the input list when the given expression was found or -1 if not found.
 zfInline index(cond: bool):
@@ -1423,7 +1426,7 @@ proc inlineReduce(ext: ExtNimNode) {.compileTime.} =
           initAccu = false
         else:
           let oldValue = result.elem
-          # assign the new iterator to the old value as accumulator 
+          # assign the new iterator to the old value as accumulator
           # before calling the operation `op`
           let it = mkAccuResult(oldValue, it)
           let newValue = op
@@ -1577,7 +1580,7 @@ macro genTupleSeqCalls(maxTupleSize: static[int]): untyped =
       calls.add(newCall(nnkBracketExpr.newTree(newIdentNode("newSeq"), types[i].copyNimNode)))
     let tParam = newIdentDefs(newIdentNode("t"), paramIdents, newEmptyNode())
     params.add(retVal).add(tParam)
-    
+
     genIdents.add(newEmptyNode()).add(newEmptyNode())
 
     # generate initTupleSeq


### PR DESCRIPTION
Potentially breaking!

With this change, `enumerate` now counts the current iteration in the pipeline, not the initial collection/iterator. This makes it behave differently to `indexedMap` and brings it to being on a par with the equivalents in in Rust, Python and other languages.

```
echo 0..10 --> filter(it mod 2 == 0).enumerate().map(it.idx) == @[0, 1, 2, 3, 4, 5]
# true
```
compare to previous behaviour, which is identical to `indexedMap`
```
echo 0..10 --> filter(it mod 2 == 0).indexedMap(it).map(it.idx) == @[0, 2, 4, 6, 8, 10]
# true
```

Test added, Readme edited to reflect changes. Fixes #66

If you're concerned this clashes with `std/enumerate`, we could change the name. However, `std/enumerate` is unnecessary if using zero_functional. Users should be discouraged from using the current templates from standard library in combination with zero_functional.